### PR TITLE
Installation fix

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -2,8 +2,9 @@
 #
 # Common setup for all servers (Control Plane and Nodes)
 
-sudo zypper update
-sudo zypper refresh
+sudo zypper --non-interactive update
+sudo zypper --non-interactive refresh
+sudo zypper install -y cron
 
 #ensure the swap is disable
 sudo swapoff -a


### PR DESCRIPTION
The --non-interactive flags are only cosmetics but the cron is needed to be able to work properly after restart.